### PR TITLE
punctuation: 替换原来的模块调用为http API访问

### DIFF
--- a/controller/com/api.py
+++ b/controller/com/api.py
@@ -9,12 +9,17 @@ from controller.base import BaseHandler
 from controller.page.tool.esearch import find
 from controller.page.tool.variant import normalize
 
-try:
-    import punctuation
 
-    punc_str = punctuation.punc_str
-except Exception:
-    punc_str = lambda s: s
+def punc_str(orig_str):
+    import requests
+    import logging
+    try:
+        res = requests.get("http://localhost:10888/seg", params={'q': orig_str}, timeout=0.1)
+    except Exception as e:
+        logging.error(str(e))
+        return orig_str
+
+    return res.text
 
 
 class PunctuationApi(BaseHandler):

--- a/main.py
+++ b/main.py
@@ -10,8 +10,6 @@ import sys
 import socket
 import logging
 
-sys.path.append('/extra_modules')
-
 from tornado.httpserver import HTTPServer
 from tornado import ioloop, netutil, process
 from tornado.options import define, options as opt


### PR DESCRIPTION
在部署时，把自动标点换成一个单独的web服务（内部网络10888端口）
相应的，在这里把原来的模块调用替换成访问此服务
可以解决原来多进程不工作的问题，而且一劳永逸，可以把自动标点
模块带入的很多AI相关的依赖模块清理掉。

此改动，需要调用一个新的依赖模块requests，但是它已经被其它模块
间接依赖，安装到现有运行环境中了，所以暂时不需要改动
requirements.txt